### PR TITLE
chore: update database connection and rename tables to avoid SQL rese…

### DIFF
--- a/src/main/java/com/pablodev9/novainvest/model/Order.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Order.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
+@Table (name = "order_nova")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -29,7 +30,7 @@ public class Order {
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_nova_id")
     private User user;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "asset_id")

--- a/src/main/java/com/pablodev9/novainvest/model/Portfolio.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Portfolio.java
@@ -25,7 +25,7 @@ public class Portfolio {
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_nova_id")
     private User user;
     @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Investment> investments;

--- a/src/main/java/com/pablodev9/novainvest/model/User.java
+++ b/src/main/java/com/pablodev9/novainvest/model/User.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
+@Table(name = "user_nova")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/pablodev9/novainvest/model/Watchlist.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Watchlist.java
@@ -25,6 +25,6 @@ public class Watchlist {
     )
     private List<Asset> assets;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_nova_id")
     private User user;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
-spring.application.name=NovaInvest
+spring.datasource.url=jdbc:postgresql://localhost:5432/nova-invest
+spring.datasource.username=postgres
+spring.datasource.password=Indi-Jons12pg
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+security.basic.enabled=false


### PR DESCRIPTION
…rved keywords

- Configured database connection in `application.properties` for PostgreSQL.
- Renamed `User` entity to `user_nova` to avoid conflict with SQL reserved keywords.
- Renamed `Order` entity to `order_nova` for the same reason.