### PR TITLE
refactor: move entity methods to service layer for cleaner business l…

### DIFF
--- a/src/main/java/com/pablodev9/novainvest/model/Account.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Account.java
@@ -1,6 +1,5 @@
 package com.pablodev9.novainvest.model;
 
-import com.pablodev9.novainvest.model.enums.OrderStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -34,52 +33,7 @@ public class Account {
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Transaction> transactions;
 
-    public BigDecimal calculateBalance() {
-        BigDecimal totalPortfolioValue = BigDecimal.ZERO;
 
-        for (Portfolio portfolio : portfolios) {
-            if (portfolio != null) {
-                totalPortfolioValue = totalPortfolioValue.add(portfolio.calculateTotalValue());
-            }
-        }
-
-        // Total balance is the sum of portfolio values + equity + reserved funds
-        return totalPortfolioValue.add(equity).add(reservedFunds);
-    }
-
-    public BigDecimal calculateEquity() {
-        return calculateBalance().subtract(calculateMargin()).subtract(calculateReservedFunds());
-    }
-
-    public BigDecimal calculateMargin() {
-        BigDecimal totalMargin = BigDecimal.ZERO;
-
-        for (Portfolio portfolio : portfolios) {
-            if (portfolio != null) {
-                for (Investment investment : portfolio.getInvestments()) {
-                    totalMargin = totalMargin.add(investment.calculateAmountInvested());
-                }
-            }
-        }
-
-        return totalMargin;
-    }
-
-    public BigDecimal calculateReservedFunds() {
-        BigDecimal totalReservedFunds = BigDecimal.ZERO;
-
-        for (Portfolio portfolio : portfolios) {
-            if (portfolio != null) {
-                for (Order order : portfolio.getOrders()) {
-                    if (order.getOrderStatus().equals(OrderStatus.PENDING)) {
-                        totalReservedFunds = totalReservedFunds.add( order.getPrice().multiply(BigDecimal.valueOf(order.getQuantity()))
-                        );
-                    }
-                }
-            }
-        }
-        return totalReservedFunds;
-    }
 
 
     @PrePersist

--- a/src/main/java/com/pablodev9/novainvest/model/Investment.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Investment.java
@@ -33,16 +33,6 @@ public class Investment {
     @JoinColumn(name = "asset_id")
     private Asset asset;
 
-    public BigDecimal calculateAmountInvested() {
-        return purchasePrice.multiply(BigDecimal.valueOf(quantity)).add(transactionFees);
-    }
-
-    public BigDecimal calculateProfitOrLoss() {
-        BigDecimal initialInvestmentCost = purchasePrice.multiply(BigDecimal.valueOf(quantity)).add(transactionFees);
-        BigDecimal currentValue = currentPrice.multiply(BigDecimal.valueOf(quantity));
-        return currentValue.subtract(initialInvestmentCost);
-    }
-
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/pablodev9/novainvest/model/Order.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Order.java
@@ -28,6 +28,8 @@ public class Order {
     private OrderStatus orderStatus;
     @Enumerated(EnumType.STRING)
     private PriceType priceType;
+    private BigDecimal stopLoss;
+    private BigDecimal takeProfit;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/pablodev9/novainvest/model/Portfolio.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Portfolio.java
@@ -32,19 +32,6 @@ public class Portfolio {
     @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Order> orders;
 
-    public BigDecimal calculateTotalValue() {
-        BigDecimal totalValue = BigDecimal.ZERO;
-
-        for (Investment investment : investments) {
-            if (investment != null) {
-                BigDecimal amountInvested = (investment.calculateAmountInvested() != null ? investment.calculateAmountInvested() : BigDecimal.ZERO);
-                BigDecimal investmentValue = investment.calculateProfitOrLoss();
-                totalValue = totalValue.add(amountInvested).add(investmentValue);
-            }
-        }
-        return totalValue;
-    }
-
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/pablodev9/novainvest/model/Watchlist.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Watchlist.java
@@ -24,6 +24,7 @@ public class Watchlist {
             inverseJoinColumns = @JoinColumn(name = "asset_id")
     )
     private List<Asset> assets;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_nova_id")
     private Portfolio portfolio;

--- a/src/main/java/com/pablodev9/novainvest/service/AccountService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/AccountService.java
@@ -1,13 +1,14 @@
 package com.pablodev9.novainvest.service;
 
-import com.pablodev9.novainvest.model.Account;
-import com.pablodev9.novainvest.model.User;
+import com.pablodev9.novainvest.model.*;
 import com.pablodev9.novainvest.model.dto.AccountPortfolioDto;
 import com.pablodev9.novainvest.model.dto.TransactionDto;
+import com.pablodev9.novainvest.model.enums.OrderStatus;
 import com.pablodev9.novainvest.repository.AccountRepository;
 import com.pablodev9.novainvest.service.mapper.AccountMapper;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +22,14 @@ public class AccountService {
     private AccountRepository accountRepository;
 
     @Autowired
+    @Lazy
     private AccountMapper accountMapper;
+
+    @Autowired
+    private PortfolioService portfolioService;
+
+    @Autowired
+    private InvestmentService investmentService;
 
 
     public void createAccountForUser(User user) {
@@ -33,6 +41,10 @@ public class AccountService {
         account.setReservedFunds(BigDecimal.ZERO);
         account.setCreatedAt(account.getCreatedAt());
         accountRepository.save(account);
+    }
+
+    public Account save(Account account) {
+        return accountRepository.save(account);
     }
 
     @Transactional
@@ -70,5 +82,52 @@ public class AccountService {
 
     private void deposit(Account account, BigDecimal amount) {
         account.setBalance(account.getBalance().add(amount));
+    }
+
+    public BigDecimal calculateBalance(Account account) {
+        BigDecimal totalPortfolioValue = BigDecimal.ZERO;
+
+        for (Portfolio portfolio : account.getPortfolios()) {
+            if (portfolio != null) {
+                totalPortfolioValue = totalPortfolioValue.add(portfolioService.calculateTotalValue(portfolio));
+            }
+        }
+
+        return totalPortfolioValue.add(account.getEquity()).add(account.getReservedFunds());
+    }
+
+    public BigDecimal calculateEquity(Account account) {
+        return calculateBalance(account)
+                .subtract(calculateMargin(account))
+                .subtract(calculateReservedFunds(account));
+    }
+
+    public BigDecimal calculateMargin(Account account) {
+        BigDecimal totalMargin = BigDecimal.ZERO;
+
+        for (Portfolio portfolio : account.getPortfolios()) {
+            if (portfolio != null) {
+                for (Investment investment : portfolio.getInvestments()) {
+                    totalMargin = totalMargin.add(investmentService.calculateAmountInvested(investment));
+                }
+            }
+        }
+        return totalMargin;
+    }
+
+    public BigDecimal calculateReservedFunds(Account account) {
+        BigDecimal totalReservedFunds = BigDecimal.ZERO;
+
+        for (Portfolio portfolio : account.getPortfolios()) {
+            if (portfolio != null) {
+                for (Order order : portfolio.getOrders()) {
+                    if (order.getOrderStatus().equals(OrderStatus.PENDING)) {
+                        totalReservedFunds = totalReservedFunds.add(order.getPrice().multiply(BigDecimal.valueOf(order.getQuantity()))
+                        );
+                    }
+                }
+            }
+        }
+        return totalReservedFunds;
     }
 }

--- a/src/main/java/com/pablodev9/novainvest/service/InvestmentService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/InvestmentService.java
@@ -1,0 +1,25 @@
+package com.pablodev9.novainvest.service;
+
+import com.pablodev9.novainvest.model.Investment;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+public class InvestmentService {
+
+    public BigDecimal calculateAmountInvested(Investment investment) {
+        return investment.getPurchasePrice()
+                .multiply(BigDecimal.valueOf(investment.getQuantity()))
+                .add(investment.getTransactionFees());
+    }
+
+    public BigDecimal calculateProfitOrLoss(Investment investment) {
+        BigDecimal initialInvestmentCost = investment.getPurchasePrice()
+                .multiply(BigDecimal.valueOf(investment.getQuantity()))
+                .add(investment.getTransactionFees());
+        BigDecimal currentValue = investment.getCurrentPrice()
+                .multiply(BigDecimal.valueOf(investment.getQuantity()));
+        return currentValue.subtract(initialInvestmentCost);
+    }
+}

--- a/src/main/java/com/pablodev9/novainvest/service/PortfolioService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/PortfolioService.java
@@ -1,11 +1,14 @@
 package com.pablodev9.novainvest.service;
 
+import com.pablodev9.novainvest.model.Investment;
 import com.pablodev9.novainvest.model.Portfolio;
 import com.pablodev9.novainvest.model.dto.PortfolioDto;
 import com.pablodev9.novainvest.repository.PortfolioRepository;
 import com.pablodev9.novainvest.service.mapper.PortfolioMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
 
 @Service
 public class PortfolioService {
@@ -16,9 +19,25 @@ public class PortfolioService {
     @Autowired
     private PortfolioRepository portfolioRepository;
 
+    @Autowired
+    private InvestmentService investmentService;
+
     public PortfolioDto createPortfolio(final PortfolioDto portfolioDto) {
         final Portfolio portfolio = portfolioMapper.dtoToPortfolio(portfolioDto);
         final Portfolio savedPortfolio = portfolioRepository.save(portfolio);
         return portfolioMapper.portfolioToDto(savedPortfolio);
+    }
+
+    public BigDecimal calculateTotalValue(Portfolio portfolio) {
+        BigDecimal totalValue = BigDecimal.ZERO;
+
+        for (Investment investment : portfolio.getInvestments()) {
+            if (investment != null) {
+                BigDecimal amountInvested = (investmentService.calculateAmountInvested(investment) != null ? investmentService.calculateAmountInvested(investment) : BigDecimal.ZERO);
+                BigDecimal investmentValue = investmentService.calculateProfitOrLoss(investment);
+                totalValue = totalValue.add(amountInvested).add(investmentValue);
+            }
+        }
+        return totalValue;
     }
 }

--- a/src/main/java/com/pablodev9/novainvest/service/TransactionService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/TransactionService.java
@@ -1,5 +1,6 @@
 package com.pablodev9.novainvest.service;
 
+import com.pablodev9.novainvest.model.Account;
 import com.pablodev9.novainvest.model.Transaction;
 import com.pablodev9.novainvest.model.dto.TransactionDto;
 import com.pablodev9.novainvest.model.dto.TransactionResponseDto;
@@ -25,6 +26,8 @@ public class TransactionService {
     public TransactionResponseDto depositOrWithdrawal(final TransactionDto transactionDto) {
         final Transaction transaction = transactionMapper.requestDtoToEntity(transactionDto);
         accountService.updateAccountBalance(transactionDto);
+        final Account updatedAccount = accountService.findAccountById(transactionDto.getAccountId());
+        accountService.save(updatedAccount);
         final Transaction savedTransaction = transactionRepository.save(transaction);
         return transactionMapper.entityToResponseDto(savedTransaction);
     }

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/AccountMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/AccountMapper.java
@@ -2,6 +2,7 @@ package com.pablodev9.novainvest.service.mapper;
 
 import com.pablodev9.novainvest.model.Account;
 import com.pablodev9.novainvest.model.dto.AccountPortfolioDto;
+import com.pablodev9.novainvest.service.AccountService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -10,14 +11,16 @@ public class AccountMapper {
 
     @Autowired
     private PortfolioMapper portfolioMapper;
+    @Autowired
+    private AccountService accountService;
 
     public AccountPortfolioDto toResponseDto(final Account account) {
         return AccountPortfolioDto.builder()
                 .id(account.getId())
-                .balance(account.calculateBalance())
-                .equity(account.calculateEquity())
-                .margin(account.calculateMargin())
-                .reservedFunds(account.calculateReservedFunds())
+                .balance(accountService.calculateBalance(account))
+                .equity(accountService.calculateEquity(account))
+                .margin(accountService.calculateMargin(account))
+                .reservedFunds(accountService.calculateReservedFunds(account))
                 .updatedAt(account.getUpdatedAt().toString())
                 .portfolioSummaryDtos(portfolioMapper.toSummaryDtos(account.getPortfolios()))
                 .build();

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/InvestmentMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/InvestmentMapper.java
@@ -2,6 +2,8 @@ package com.pablodev9.novainvest.service.mapper;
 
 import com.pablodev9.novainvest.model.Investment;
 import com.pablodev9.novainvest.model.dto.InvestmentSummaryDto;
+import com.pablodev9.novainvest.service.InvestmentService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -10,15 +12,18 @@ import java.util.List;
 @Service
 public class InvestmentMapper {
 
+    @Autowired
+    private InvestmentService investmentService;
+
     public List<InvestmentSummaryDto> toSummaryDtos(List<Investment> investments) {
         List<InvestmentSummaryDto> investmentSummaryDtos = new ArrayList<>();
         for (Investment investment : investments) {
             InvestmentSummaryDto investmentSummaryDto = InvestmentSummaryDto.builder()
                     .investmentId(investment.getId())
                     .assetName(investment.getAsset().getName())
-                    .amountInvested(investment.calculateAmountInvested())
+                    .amountInvested(investmentService.calculateAmountInvested(investment))
                     .currentValue(investment.getCurrentPrice())
-                    .profitOrLoss(investment.calculateProfitOrLoss())
+                    .profitOrLoss(investmentService.calculateProfitOrLoss(investment))
                     .build();
             investmentSummaryDtos.add(investmentSummaryDto);
         }

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/PortfolioMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/PortfolioMapper.java
@@ -4,6 +4,7 @@ import com.pablodev9.novainvest.model.Portfolio;
 import com.pablodev9.novainvest.model.dto.PortfolioDto;
 import com.pablodev9.novainvest.model.dto.PortfolioSummaryDto;
 import com.pablodev9.novainvest.service.AccountService;
+import com.pablodev9.novainvest.service.PortfolioService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,10 @@ public class PortfolioMapper {
 
     @Autowired
     @Lazy
+    private PortfolioService portfolioService;
+
+    @Autowired
+    @Lazy
     private AccountService accountService;
 
     public List<PortfolioSummaryDto> toSummaryDtos(final List<Portfolio> portfolios) {
@@ -28,7 +33,7 @@ public class PortfolioMapper {
             PortfolioSummaryDto portfolioSummaryDto = PortfolioSummaryDto.builder()
                     .id(portfolio.getId())
                     .portfolioName(portfolio.getName())
-                    .totalValue(portfolio.calculateTotalValue())
+                    .totalValue(portfolioService.calculateTotalValue(portfolio))
                     .investmentSummaryDtos(investmentMapper.toSummaryDtos(portfolio.getInvestments()))
                     .build();
             portfolioSummaryDtos.add(portfolioSummaryDto);


### PR DESCRIPTION
…ogic

- Moved `calculateBalance`, `calculateEquity`, `calculateMargin`, and `calculateReservedFunds` from `Account` entity to `AccountService` for encapsulating business logic.
- Shifted investment-related calculations from `Investment` entity to `InvestmentService`.
- Transferred portfolio-related calculations from `Portfolio` entity to `PortfolioService`.
- Updated mappers `AccountMapper` and `PortfolioMapper` to reflect the service-layer logic.