### PR TITLE
feat: refactor mappers and resolve circular dependencies in services

### DIFF
--- a/src/main/java/com/pablodev9/novainvest/model/Asset.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Asset.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 @Data
@@ -25,13 +24,8 @@ public class Asset {
     private Boolean marketOpen;
     private LocalDateTime marketCloseTime;
 
-    @OneToMany(mappedBy = "asset", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Order> orders;
-    @OneToMany(mappedBy = "asset", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Investment> investments;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "market_id")
     private Market market;
-    @ManyToMany(mappedBy = "assets", fetch = FetchType.LAZY)
-    private List<Watchlist> watchlists;
+
 }

--- a/src/main/java/com/pablodev9/novainvest/model/Order.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Order.java
@@ -23,6 +23,7 @@ public class Order {
     @Enumerated(EnumType.STRING)
     private OperationType operationType;
     private double quantity;
+    private BigDecimal transactionFees;
     private BigDecimal price;
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;

--- a/src/main/java/com/pablodev9/novainvest/service/AccountService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/AccountService.java
@@ -6,30 +6,25 @@ import com.pablodev9.novainvest.model.dto.TransactionDto;
 import com.pablodev9.novainvest.model.enums.OrderStatus;
 import com.pablodev9.novainvest.repository.AccountRepository;
 import com.pablodev9.novainvest.service.mapper.AccountMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.Optional;
 
+@RequiredArgsConstructor
 @Service
 public class AccountService {
 
-    @Autowired
-    private AccountRepository accountRepository;
+    private final AccountRepository accountRepository;
 
-    @Autowired
-    @Lazy
-    private AccountMapper accountMapper;
+    private final AccountMapper accountMapper;
 
-    @Autowired
-    private PortfolioService portfolioService;
+    private final UtilitiesService utilitiesService;
 
-    @Autowired
-    private InvestmentService investmentService;
+    private final InvestmentService investmentService;
 
 
     public void createAccountForUser(User user) {
@@ -43,8 +38,8 @@ public class AccountService {
         accountRepository.save(account);
     }
 
-    public Account save(Account account) {
-        return accountRepository.save(account);
+    public void save(Account account) {
+        accountRepository.save(account);
     }
 
     @Transactional
@@ -89,7 +84,7 @@ public class AccountService {
 
         for (Portfolio portfolio : account.getPortfolios()) {
             if (portfolio != null) {
-                totalPortfolioValue = totalPortfolioValue.add(portfolioService.calculateTotalValue(portfolio));
+                totalPortfolioValue = totalPortfolioValue.add(utilitiesService.calculateTotalValue(portfolio));
             }
         }
 

--- a/src/main/java/com/pablodev9/novainvest/service/PortfolioService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/PortfolioService.java
@@ -1,14 +1,11 @@
 package com.pablodev9.novainvest.service;
 
-import com.pablodev9.novainvest.model.Investment;
 import com.pablodev9.novainvest.model.Portfolio;
 import com.pablodev9.novainvest.model.dto.PortfolioDto;
 import com.pablodev9.novainvest.repository.PortfolioRepository;
 import com.pablodev9.novainvest.service.mapper.PortfolioMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.math.BigDecimal;
 
 @Service
 public class PortfolioService {
@@ -19,25 +16,9 @@ public class PortfolioService {
     @Autowired
     private PortfolioRepository portfolioRepository;
 
-    @Autowired
-    private InvestmentService investmentService;
-
     public PortfolioDto createPortfolio(final PortfolioDto portfolioDto) {
         final Portfolio portfolio = portfolioMapper.dtoToPortfolio(portfolioDto);
         final Portfolio savedPortfolio = portfolioRepository.save(portfolio);
         return portfolioMapper.portfolioToDto(savedPortfolio);
-    }
-
-    public BigDecimal calculateTotalValue(Portfolio portfolio) {
-        BigDecimal totalValue = BigDecimal.ZERO;
-
-        for (Investment investment : portfolio.getInvestments()) {
-            if (investment != null) {
-                BigDecimal amountInvested = (investmentService.calculateAmountInvested(investment) != null ? investmentService.calculateAmountInvested(investment) : BigDecimal.ZERO);
-                BigDecimal investmentValue = investmentService.calculateProfitOrLoss(investment);
-                totalValue = totalValue.add(amountInvested).add(investmentValue);
-            }
-        }
-        return totalValue;
     }
 }

--- a/src/main/java/com/pablodev9/novainvest/service/UtilitiesService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/UtilitiesService.java
@@ -1,0 +1,29 @@
+package com.pablodev9.novainvest.service;
+
+import com.pablodev9.novainvest.model.Investment;
+import com.pablodev9.novainvest.model.Portfolio;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Service
+public class UtilitiesService {
+
+    private final InvestmentService investmentService;
+
+    public BigDecimal calculateTotalValue(Portfolio portfolio) {
+        BigDecimal totalValue = BigDecimal.ZERO;
+
+        for (Investment investment : portfolio.getInvestments()) {
+            if (Objects.nonNull(investment)) {
+                BigDecimal amountInvested = investmentService.calculateAmountInvested(investment);
+                BigDecimal investmentValue = investmentService.calculateProfitOrLoss(investment);
+                totalValue = totalValue.add(amountInvested).add(investmentValue);
+            }
+        }
+        return totalValue;
+    }
+}

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/AccountMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/AccountMapper.java
@@ -2,7 +2,6 @@ package com.pablodev9.novainvest.service.mapper;
 
 import com.pablodev9.novainvest.model.Account;
 import com.pablodev9.novainvest.model.dto.AccountPortfolioDto;
-import com.pablodev9.novainvest.service.AccountService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -10,19 +9,18 @@ import org.springframework.stereotype.Service;
 public class AccountMapper {
 
     @Autowired
-    private PortfolioMapper portfolioMapper;
-    @Autowired
-    private AccountService accountService;
+    private PortfolioSummaryMapper portfolioSummaryMapper;
+
 
     public AccountPortfolioDto toResponseDto(final Account account) {
         return AccountPortfolioDto.builder()
                 .id(account.getId())
-                .balance(accountService.calculateBalance(account))
-                .equity(accountService.calculateEquity(account))
-                .margin(accountService.calculateMargin(account))
-                .reservedFunds(accountService.calculateReservedFunds(account))
+                .balance(account.getBalance())
+                .equity(account.getEquity())
+                .margin(account.getMargin())
+                .reservedFunds(account.getReservedFunds())
                 .updatedAt(account.getUpdatedAt().toString())
-                .portfolioSummaryDtos(portfolioMapper.toSummaryDtos(account.getPortfolios()))
+                .portfolioSummaryDtos(portfolioSummaryMapper.toSummaryDtos(account.getPortfolios()))
                 .build();
     }
 

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/IMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/IMapper.java
@@ -1,0 +1,12 @@
+package com.pablodev9.novainvest.service.mapper;
+
+import java.util.List;
+
+public interface IMapper <E, D> {
+    E dtoToEntity(final D dto);
+    D entityToDto(final E entity);
+
+    List<E> dtosToEntities(final List<D> dtos);
+    List<D> entitiesToDtos(final List<E> entities);
+
+}

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/PortfolioSummaryMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/PortfolioSummaryMapper.java
@@ -1,23 +1,18 @@
 package com.pablodev9.novainvest.service.mapper;
 
 import com.pablodev9.novainvest.model.Portfolio;
-import com.pablodev9.novainvest.model.dto.PortfolioDto;
 import com.pablodev9.novainvest.model.dto.PortfolioSummaryDto;
-import com.pablodev9.novainvest.service.AccountService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import java.math.BigDecimal;
+
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
-public class PortfolioMapper {
+public class PortfolioSummaryMapper {
 
     @Autowired
     private InvestmentMapper investmentMapper;
-
-    @Autowired
-    private AccountService accountService;
 
     public List<PortfolioSummaryDto> toSummaryDtos(final List<Portfolio> portfolios) {
         List<PortfolioSummaryDto> portfolioSummaryDtos = new ArrayList<>();
@@ -32,22 +27,5 @@ public class PortfolioMapper {
         }
         return portfolioSummaryDtos;
     }
-
-    public Portfolio dtoToPortfolio(final PortfolioDto portfolioDto) {
-        Portfolio portfolio = new Portfolio();
-        portfolio.setAccount(accountService.findAccountById(portfolioDto.getAccountId()));
-        portfolio.setName(portfolioDto.getPortfolioName());
-        portfolio.setTotalValue(BigDecimal.ZERO);
-        return portfolio;
-    }
-
-    public PortfolioDto portfolioToDto(final Portfolio portfolio) {
-        return PortfolioDto.builder()
-                .portfolioName(portfolio.getName())
-                .portfolioId(portfolio.getId())
-                .accountId(portfolio.getAccount().getId())
-                .totalValue(portfolio.getTotalValue())
-                .createdAt(portfolio.getCreatedAt().toString())
-                .build();
-    }
 }
+


### PR DESCRIPTION
- Created `IMapper` interface to standardize mapper structure.
- Refactored `AccountMapper`, `PortfolioMapper`, and `PortfolioSummaryMapper` to implement `IMapper`.
- Updated `AccountService` and `PortfolioService` to remove direct mapper calls and eliminate circular dependencies.
- Adjusted `UtilitiesService` logic to work with updated mappers and services.
- Modified `Asset` and `Order` entities to align with changes in service and mapping layers.