### PR TITLE
feat: complete portfolio details retrieval with mappers

### DIFF
--- a/src/main/java/com/pablodev9/novainvest/model/Order.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Order.java
@@ -24,6 +24,7 @@ public class Order {
     private OrderType orderType;
     private double quantity;
     private BigDecimal transactionFees;
+    private BigDecimal purchasePrice;
     private BigDecimal price;
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;

--- a/src/main/java/com/pablodev9/novainvest/model/dto/OrderDto.java
+++ b/src/main/java/com/pablodev9/novainvest/model/dto/OrderDto.java
@@ -1,0 +1,21 @@
+package com.pablodev9.novainvest.model.dto;
+
+import com.pablodev9.novainvest.model.enums.OrderStatus;
+import com.pablodev9.novainvest.model.enums.OrderType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+public class OrderDto {
+    private final Long orderId;
+    private final String assetName;
+    private final BigDecimal amountInvested;
+    private final BigDecimal profitOrLoss;
+    private final OrderStatus orderStatus;
+    private final OrderType orderType;
+}

--- a/src/main/java/com/pablodev9/novainvest/model/dto/PortfolioResponseDto.java
+++ b/src/main/java/com/pablodev9/novainvest/model/dto/PortfolioResponseDto.java
@@ -17,6 +17,6 @@ public class PortfolioResponseDto {
     private final BigDecimal totalValue;
     private final String updateAt;
     private final List<WatchlistResponseDto> watchlistResponseDtos;
-    private final List<AssetResponseDto> assetResponseDtos;
+    private final List<OrderDto> orderResponseDtos;
     private final List<InvestmentSummaryDto> investmentSummaryDtos;
 }

--- a/src/main/java/com/pablodev9/novainvest/service/OrderService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/OrderService.java
@@ -1,0 +1,27 @@
+package com.pablodev9.novainvest.service;
+
+import com.pablodev9.novainvest.model.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@RequiredArgsConstructor
+@Service
+public class OrderService {
+
+    public BigDecimal calculateAmountInvested(Order order) {
+        return order.getPurchasePrice()
+                .multiply(BigDecimal.valueOf(order.getQuantity()))
+                .add(order.getTransactionFees());
+    }
+
+    public BigDecimal calculateProfitOrLoss(Order order) {
+        BigDecimal initialInvestmentCost = order.getPurchasePrice()
+                .multiply(BigDecimal.valueOf(order.getQuantity()))
+                .add(order.getTransactionFees());
+        BigDecimal currentValue = order.getPrice()
+                .multiply(BigDecimal.valueOf(order.getQuantity()));
+        return currentValue.subtract(initialInvestmentCost);
+    }
+}

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/AssetMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/AssetMapper.java
@@ -1,0 +1,25 @@
+package com.pablodev9.novainvest.service.mapper;
+
+import com.pablodev9.novainvest.model.Asset;
+import com.pablodev9.novainvest.model.dto.AssetResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class AssetMapper {
+
+    public List<AssetResponseDto> toSummaryDtos(final List<Asset> assets) {
+        return assets.stream()
+                .map(asset -> AssetResponseDto.builder()
+                        .assetId(asset.getId())
+                        .name(asset.getName())
+                        .assetType(asset.getAssetType())
+                        .currentPrice(asset.getCurrentPrice())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/OrderMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/OrderMapper.java
@@ -1,0 +1,31 @@
+package com.pablodev9.novainvest.service.mapper;
+
+import com.pablodev9.novainvest.model.Order;
+import com.pablodev9.novainvest.model.dto.OrderDto;
+import com.pablodev9.novainvest.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class OrderMapper {
+
+    private final OrderService orderService;
+
+    public List<OrderDto> toSummaryDtos(List<Order> orders) {
+        return orders.stream()
+                .map(order -> OrderDto.builder()
+                        .orderId(order.getId())
+                        .assetName(order.getAsset().getName())
+                        .amountInvested(orderService.calculateAmountInvested(order))
+                        .orderStatus(order.getOrderStatus())
+                        .orderType(order.getOrderType())
+                        .profitOrLoss(orderService.calculateProfitOrLoss(order))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/PortfolioDetailMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/PortfolioDetailMapper.java
@@ -2,13 +2,18 @@ package com.pablodev9.novainvest.service.mapper;
 
 import com.pablodev9.novainvest.model.Portfolio;
 import com.pablodev9.novainvest.model.dto.PortfolioResponseDto;
-import com.pablodev9.novainvest.service.AccountService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class PortfolioDetailMapper {
+
+    private final WatchlistMapper watchlistMapper;
+
+    private final InvestmentMapper investmentMapper;
+
+    private final OrderMapper orderMapper;
 
     public PortfolioResponseDto entityToDto(final Portfolio portfolio) {
         return PortfolioResponseDto.builder()
@@ -17,6 +22,9 @@ public class PortfolioDetailMapper {
                 .portfolioName(portfolio.getName())
                 .totalValue(portfolio.getTotalValue())
                 .updateAt(portfolio.getUpdatedAt().toString())
+                .watchlistResponseDtos(watchlistMapper.toSummaryDtos(portfolio.getWatchlists()))
+                .investmentSummaryDtos(investmentMapper.toSummaryDtos(portfolio.getInvestments()))
+                .orderResponseDtos(orderMapper.toSummaryDtos(portfolio.getOrders()))
                 .build();
     }
 

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/WatchlistMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/WatchlistMapper.java
@@ -1,0 +1,27 @@
+package com.pablodev9.novainvest.service.mapper;
+
+import com.pablodev9.novainvest.model.Watchlist;
+import com.pablodev9.novainvest.model.dto.WatchlistResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class WatchlistMapper {
+
+    private final AssetMapper assetMapper;
+
+    public List<WatchlistResponseDto> toSummaryDtos(final List<Watchlist> watchlists) {
+        return watchlists.stream()
+                .map(watchlist -> WatchlistResponseDto.builder()
+                        .watchlistId(watchlist.getId())
+                        .name(watchlist.getName())
+                        .assetResponseDtos(assetMapper.toSummaryDtos(watchlist.getAssets()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+}
+


### PR DESCRIPTION
- Implemented `PortfolioDetailMapper` for detailed portfolio data transformation.
- Created and configured `OrderMapper` for order-to-DTO mapping.
- Added `OrderDto` for structured order response representation.
- Refined `AssetMapper` and `WatchlistMapper` to handle asset and watchlist data in portfolio details.
- Updated `UtilitiesService` to support mapping and calculations for portfolio details.
- Added `OrderService` support for retrieving order details within portfolios.