### PR TITLE
feat: add and implement order functionality for portfolios

### DIFF
--- a/src/main/java/com/pablodev9/novainvest/controller/OrderController.java
+++ b/src/main/java/com/pablodev9/novainvest/controller/OrderController.java
@@ -1,0 +1,34 @@
+package com.pablodev9.novainvest.controller;
+
+import com.pablodev9.novainvest.model.dto.OrderDto;
+import com.pablodev9.novainvest.model.dto.OrderResponseDto;
+import com.pablodev9.novainvest.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/api/order")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping("/add")
+    private ResponseEntity<OrderResponseDto> addOrderToPortfolio(@RequestBody final OrderDto orderDto) {
+        return ResponseEntity.ok(orderService.addOrderToPortfolio(orderDto));
+    }
+/*
+    @GetMapping("/{investmentId}")
+    private ResponseEntity<InvestmentResponseDto> getInvestmentDetails(@PathVariable final Long investmentId) {
+        return ResponseEntity.ok(orderService.getInvestmentDetails(investmentId));
+    }
+
+    @PatchMapping("{investmentId}/closed/")
+    private ResponseEntity<Long> closeInvestment(@PathVariable final Long investmentId) {
+        return ResponseEntity.ok(investmentService.closeInvestment(investmentId));
+    }*/
+}

--- a/src/main/java/com/pablodev9/novainvest/model/Order.java
+++ b/src/main/java/com/pablodev9/novainvest/model/Order.java
@@ -23,6 +23,7 @@ public class Order {
     @Enumerated(EnumType.STRING)
     private OrderType orderType;
     private BigDecimal quantity;
+    private BigDecimal amountInvested;
     private BigDecimal transactionFees;
     private BigDecimal purchasePrice;
     private BigDecimal price;

--- a/src/main/java/com/pablodev9/novainvest/model/dto/OrderResponseDto.java
+++ b/src/main/java/com/pablodev9/novainvest/model/dto/OrderResponseDto.java
@@ -6,15 +6,24 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
 @RequiredArgsConstructor
-public class OrderDto {
+public class OrderResponseDto {
     private final Long portfolioId;
-    private final Long assetId;
-    private final BigDecimal quantity;
+    private final Long orderId;
     private final OrderType orderType;
+    private final Long assetId;
+    private final String assetName;
+    private final BigDecimal quantity;
+    private final BigDecimal amountInvested;
     private final BigDecimal takeProfit;
     private final BigDecimal stopLoss;
+    private final BigDecimal transactionFees;
+    private final BigDecimal purchasePrice;
+    private final BigDecimal currentValue;
+    private final BigDecimal profitOrLoss;
+    private final LocalDateTime createdAt;
 }

--- a/src/main/java/com/pablodev9/novainvest/model/dto/OrderSummaryDto.java
+++ b/src/main/java/com/pablodev9/novainvest/model/dto/OrderSummaryDto.java
@@ -1,5 +1,6 @@
 package com.pablodev9.novainvest.model.dto;
 
+import com.pablodev9.novainvest.model.enums.OrderStatus;
 import com.pablodev9.novainvest.model.enums.OrderType;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,11 +11,11 @@ import java.math.BigDecimal;
 @Builder
 @Getter
 @RequiredArgsConstructor
-public class OrderDto {
-    private final Long portfolioId;
-    private final Long assetId;
-    private final BigDecimal quantity;
+public class OrderSummaryDto {
+    private final Long orderId;
+    private final String assetName;
+    private final BigDecimal amountInvested;
+    private final BigDecimal profitOrLoss;
+    private final OrderStatus orderStatus;
     private final OrderType orderType;
-    private final BigDecimal takeProfit;
-    private final BigDecimal stopLoss;
 }

--- a/src/main/java/com/pablodev9/novainvest/model/dto/PortfolioResponseDto.java
+++ b/src/main/java/com/pablodev9/novainvest/model/dto/PortfolioResponseDto.java
@@ -17,6 +17,6 @@ public class PortfolioResponseDto {
     private final BigDecimal totalValue;
     private final String updateAt;
     private final List<WatchlistResponseDto> watchlistResponseDtos;
-    private final List<OrderDto> orderResponseDtos;
+    private final List<OrderSummaryDto> orderResponseDtos;
     private final List<InvestmentSummaryDto> investmentSummaryDtos;
 }

--- a/src/main/java/com/pablodev9/novainvest/repository/OrderRepository.java
+++ b/src/main/java/com/pablodev9/novainvest/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.pablodev9.novainvest.repository;
+
+import com.pablodev9.novainvest.model.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/pablodev9/novainvest/service/AccountFinancialOperationService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/AccountFinancialOperationService.java
@@ -45,10 +45,10 @@ public class AccountFinancialOperationService {
     public BigDecimal calculateReservedFunds(Account account) {
         return account.getPortfolios().stream()
                 .filter(Objects::nonNull)
-                .flatMap(portfolio -> portfolio.getOrders().stream()) // Flatten the orders into a single stream
-                .filter(order -> order.getOrderStatus().equals(OrderStatus.PENDING)) // Only pending orders
-                .map(order -> order.getPrice().multiply(order.getQuantity())) // Calculate reserved funds for each order
-                .reduce(BigDecimal.ZERO, BigDecimal::add); // Sum all reserved funds, starting from BigDecimal.ZERO
+                .flatMap(portfolio -> portfolio.getOrders().stream())
+                .filter(order -> order.getOrderStatus().equals(OrderStatus.PENDING))
+                .map(order -> order.getPrice().multiply(order.getQuantity()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
 }

--- a/src/main/java/com/pablodev9/novainvest/service/OrderFinancialOperationService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/OrderFinancialOperationService.java
@@ -1,0 +1,41 @@
+package com.pablodev9.novainvest.service;
+
+import com.pablodev9.novainvest.model.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@RequiredArgsConstructor
+@Service
+public class OrderFinancialOperationService {
+
+    public BigDecimal calculateAmountInvested(Order order) {
+        return order.getPurchasePrice()
+                .multiply(order.getQuantity())
+                .add(order.getTransactionFees());
+    }
+
+    public BigDecimal calculateProfitOrLoss(Order order) {
+        BigDecimal initialInvestmentCost = order.getPurchasePrice()
+                .multiply(order.getQuantity())
+                .add(order.getTransactionFees());
+        BigDecimal currentValue = order.getPrice()
+                .multiply(order.getQuantity());
+        return currentValue.subtract(initialInvestmentCost);
+    }
+
+    private static final BigDecimal TRANSACTION_FEE_RATE = new BigDecimal("0.02");
+
+    public BigDecimal calculateTransactionFees(BigDecimal purchasePrice, BigDecimal quantity) {
+        return purchasePrice.multiply(quantity).multiply(TRANSACTION_FEE_RATE);
+    }
+
+    public BigDecimal calculateCurrentValue(final Order order) {
+        BigDecimal amountInvested = order.getAmountInvested();
+        BigDecimal transactionFees = order.getTransactionFees();
+        BigDecimal profitOrLoss = calculateProfitOrLoss(order);
+
+        return amountInvested.subtract(transactionFees).add(profitOrLoss);
+    }
+}

--- a/src/main/java/com/pablodev9/novainvest/service/OrderService.java
+++ b/src/main/java/com/pablodev9/novainvest/service/OrderService.java
@@ -1,6 +1,11 @@
 package com.pablodev9.novainvest.service;
 
+import com.pablodev9.novainvest.model.Asset;
 import com.pablodev9.novainvest.model.Order;
+import com.pablodev9.novainvest.model.dto.OrderDto;
+import com.pablodev9.novainvest.model.dto.OrderResponseDto;
+import com.pablodev9.novainvest.repository.OrderRepository;
+import com.pablodev9.novainvest.service.mapper.OrderMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,18 +15,58 @@ import java.math.BigDecimal;
 @Service
 public class OrderService {
 
-    public BigDecimal calculateAmountInvested(Order order) {
-        return order.getPurchasePrice()
-                .multiply(order.getQuantity())
-                .add(order.getTransactionFees());
+    private final OrderMapper orderMapper;
+
+    private final OrderRepository orderRepository;
+
+    private final AssetService assetService;
+
+    private final OrderFinancialOperationService orderFinancialOperationService;
+
+    private final AccountService accountService;
+
+    private final PortfolioService portfolioService;
+
+    public OrderResponseDto addOrderToPortfolio(final OrderDto orderDto) {
+        final Asset asset = assetService.findAssetById(orderDto.getAssetId());
+        final BigDecimal currentPrice = asset.getCurrentPrice();
+
+        final Order order = orderMapper.dtoToOrder(orderDto);
+        order.setAsset(asset);
+        order.setPurchasePrice(currentPrice);
+        order.setAmountInvested(orderFinancialOperationService.calculateAmountInvested(order));
+        order.setTransactionFees(orderFinancialOperationService.calculateTransactionFees(currentPrice, orderDto.getQuantity()));
+        final Order savedOrder = orderRepository.save(order);
+
+        accountService.updateAccountById(order.getPortfolio().getAccount().getId());
+        portfolioService.updatePortfolioById(orderDto.getPortfolioId());
+
+        return orderMapper.orderToDto(savedOrder);
     }
 
-    public BigDecimal calculateProfitOrLoss(Order order) {
-        BigDecimal initialInvestmentCost = order.getPurchasePrice()
-                .multiply(order.getQuantity())
-                .add(order.getTransactionFees());
-        BigDecimal currentValue = order.getPrice()
-                .multiply(order.getQuantity());
-        return currentValue.subtract(initialInvestmentCost);
+    /*public InvestmentResponseDto getInvestmentDetails(final Long investmentId) {
+        final Investment investment = findInvestmentById(investmentId);
+        accountService.updateAccountById(investment.getPortfolio().getAccount().getId());
+        portfolioService.updatePortfolioById(investment.getPortfolio().getId());
+        return investmentMapper.investmentToDto(investment);
     }
+
+    public Long closeInvestment(final Long investmentId) {
+        final Investment investment = findInvestmentById(investmentId);
+        accountService.updateAccountById(investment.getPortfolio().getAccount().getId());
+        investment.setClosed(true);
+        investment.setClosedAt(LocalDateTime.now());
+        investmentRepository.save(investment);
+        return investment.getId();
+    }
+
+
+    @SneakyThrows
+    public Investment findInvestmentById(final Long investmentId) {
+        final Optional<Investment> optionalInvestment = investmentRepository.findById(investmentId);
+        if (optionalInvestment.isPresent()) {
+            return optionalInvestment.get();
+        }
+        throw new InvestmentNotFoundException(investmentId);
+    }*/
 }

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/OrderMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/OrderMapper.java
@@ -2,30 +2,46 @@ package com.pablodev9.novainvest.service.mapper;
 
 import com.pablodev9.novainvest.model.Order;
 import com.pablodev9.novainvest.model.dto.OrderDto;
-import com.pablodev9.novainvest.service.OrderService;
+import com.pablodev9.novainvest.model.dto.OrderResponseDto;
+import com.pablodev9.novainvest.service.OrderFinancialOperationService;
+import com.pablodev9.novainvest.service.PortfolioService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class OrderMapper {
 
-    private final OrderService orderService;
+    private final OrderFinancialOperationService orderFinancialOperationService;
 
-    public List<OrderDto> toSummaryDtos(List<Order> orders) {
-        return orders.stream()
-                .map(order -> OrderDto.builder()
-                        .orderId(order.getId())
-                        .assetName(order.getAsset().getName())
-                        .amountInvested(orderService.calculateAmountInvested(order))
-                        .orderStatus(order.getOrderStatus())
-                        .orderType(order.getOrderType())
-                        .profitOrLoss(orderService.calculateProfitOrLoss(order))
-                        .build())
-                .collect(Collectors.toList());
+    private final PortfolioService portfolioService;
+
+    public Order dtoToOrder(final OrderDto orderDto) {
+        Order order = new Order();
+        order.setPortfolio(portfolioService.findPortfolioById(orderDto.getPortfolioId()));
+        order.setOrderType(orderDto.getOrderType());
+        order.setQuantity(orderDto.getQuantity());
+        order.setTakeProfit(orderDto.getTakeProfit());
+        order.setStopLoss(orderDto.getStopLoss());
+        return order;
     }
 
+    public OrderResponseDto orderToDto(final Order order) {
+        return OrderResponseDto.builder()
+                .portfolioId(order.getPortfolio().getId())
+                .orderId(order.getId())
+                .orderType(order.getOrderType())
+                .assetId(order.getAsset().getId())
+                .assetName(order.getAsset().getName())
+                .quantity(order.getQuantity())
+                .takeProfit(order.getTakeProfit())
+                .stopLoss(order.getStopLoss())
+                .transactionFees(order.getTransactionFees())
+                .purchasePrice(order.getPurchasePrice())
+                .currentValue(orderFinancialOperationService.calculateCurrentValue(order))
+                .profitOrLoss(orderFinancialOperationService.calculateProfitOrLoss(order))
+                .createdAt(order.getCreatedAt())
+                .amountInvested(orderFinancialOperationService.calculateAmountInvested(order))
+                .build();
+    }
 }

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/OrderSummaryMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/OrderSummaryMapper.java
@@ -1,0 +1,31 @@
+package com.pablodev9.novainvest.service.mapper;
+
+import com.pablodev9.novainvest.model.Order;
+import com.pablodev9.novainvest.model.dto.OrderSummaryDto;
+import com.pablodev9.novainvest.service.OrderFinancialOperationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class OrderSummaryMapper {
+
+    private final OrderFinancialOperationService orderFinancialOperationService;
+
+    public List<OrderSummaryDto> toSummaryDtos(List<Order> orders) {
+        return orders.stream()
+                .map(order -> OrderSummaryDto.builder()
+                        .orderId(order.getId())
+                        .assetName(order.getAsset().getName())
+                        .amountInvested(orderFinancialOperationService.calculateAmountInvested(order))
+                        .orderStatus(order.getOrderStatus())
+                        .orderType(order.getOrderType())
+                        .profitOrLoss(orderFinancialOperationService.calculateProfitOrLoss(order))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/pablodev9/novainvest/service/mapper/PortfolioDetailMapper.java
+++ b/src/main/java/com/pablodev9/novainvest/service/mapper/PortfolioDetailMapper.java
@@ -14,7 +14,7 @@ public class PortfolioDetailMapper {
 
     private final InvestmentSummaryMapper investmentSummaryMapper;
 
-    private final OrderMapper orderMapper;
+    private final OrderSummaryMapper orderSummaryMapper;
 
     private final PortfolioFinancialOperationService portfolioFinancialOperationService;
 
@@ -27,7 +27,7 @@ public class PortfolioDetailMapper {
                 .updateAt(portfolio.getUpdatedAt().toString())
                 .watchlistResponseDtos(watchlistMapper.toSummaryDtos(portfolio.getWatchlists()))
                 .investmentSummaryDtos(investmentSummaryMapper.toSummaryDtos(portfolio.getInvestments()))
-                .orderResponseDtos(orderMapper.toSummaryDtos(portfolio.getOrders()))
+                .orderResponseDtos(orderSummaryMapper.toSummaryDtos(portfolio.getOrders()))
                 .build();
     }
 


### PR DESCRIPTION
- Created and implemented `Order` entity to represent investment orders placed by users.
- Developed `OrderService` to handle order-related business logic and integrate with portfolio operations.
- Added `OrderController` to manage order API requests, allowing users to place orders for portfolios.
- Introduced `OrderDto` and `OrderResponseDto` for data transfer and response mapping of order-related information.
- Created `OrderFinancialOperationService` to calculate financial operations related to orders.
- Implemented `OrderMapper` for mapping entities to DTOs and `OrderSummaryMapper` for order summaries.
- Updated `AccountFinancialOperationService` to accommodate order-related calculations and portfolio updates.
- Created `PortfolioDetailMapper` and `PortfolioResponseDto` to include order-related data in portfolio responses.
- Added order-related fields in the `PortfolioDetail` and `PortfolioResponseDto` to reflect placed orders and their status.